### PR TITLE
GUARD-220 Shopify Deprecation Updates

### DIFF
--- a/.build.ps1
+++ b/.build.ps1
@@ -76,12 +76,12 @@ task NuGet Package, Version, {
 	<metadata>
 		<id>$project_name</id>
 		<version>$Version</version>
-		<authors>Agile Harbor</authors>
-		<owners>Agile Harbor</owners>
+		<authors>SkuVault</authors>
+		<owners>SkuVault</owners>
 		<projectUrl>https://github.com/agileharbor/$project_name</projectUrl>
 		<licenseUrl>https://raw.github.com/agileharbor/$project_name/master/License.txt</licenseUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>
-		<copyright>Copyright (C) Agile Harbor, LLC</copyright>
+		<copyright>Copyright (C) 2019 SkuVault Inc.</copyright>
 		<summary>$text</summary>
 		<description>$text</description>
 		<tags>$project_short_name</tags>

--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -4,8 +4,8 @@ using System.Runtime.InteropServices;
 
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "ShopifyAccess" ) ]
-[ assembly : AssemblyCompany( "Agile Harbor, LLC" ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2014 Agile Harbor, LLC" ) ]
+[ assembly : AssemblyCompany( "SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2019 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Shopify webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.0.53.0" ) ]
+[ assembly : AssemblyVersion( "1.2.0.0" ) ]

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
@@ -8,21 +8,30 @@
 		public static readonly ShopifyCommand GetAccessToken = new ShopifyCommand( "/admin/oauth/access_token" );
 		public static readonly ShopifyCommand GetAllOrders = new ShopifyCommand( "/admin/orders.json" );
 		public static readonly ShopifyCommand UpdateProductVariant = new ShopifyCommand( "/admin/variants/" ); // WARN: Obsolete!!! Please use UpdateInventoryLevels
-		public static readonly ShopifyCommand UpdateInventoryLevels = new ShopifyCommand( "/inventory_levels/set.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand UpdateInventoryLevels = new ShopifyCommand( "/inventory_levels/set.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetProducts = new ShopifyCommand( "/products.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetProductsCount = new ShopifyCommand( "/products/count.json", ApiVersion.V2019_10 );
-		public static readonly ShopifyCommand GetInventoryLevels = new ShopifyCommand( "/inventory_levels.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetInventoryLevels = new ShopifyCommand( "/inventory_levels.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetOrdersCount = new ShopifyCommand( "/orders/count.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetOrders = new ShopifyCommand( "/orders.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetLocations = new ShopifyCommand( "/locations.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetUsers = new ShopifyCommand( "/admin/users.json" );
 		public static readonly ShopifyCommand GetUser = new ShopifyCommand( "/admin/users/" );
 
+		/// <summary>
+		/// Create Shopify command using the oldest supported api version
+		/// </summary>
+		/// <param name="command"></param>
 		private ShopifyCommand( string command )
 		{
 			this.Command = command;
 		}
 
+		/// <summary>
+		/// Create Shopify command using a specific api version
+		/// </summary>
+		/// <param name="commandUrl"></param>
+		/// <param name="apiVersion"></param>
 		private ShopifyCommand( string commandUrl, string apiVersion )
 		{
 			this.Command = string.Format( VersionSpecificBaseUrl, apiVersion ) + commandUrl;

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
@@ -2,17 +2,19 @@
 {
 	public class ShopifyCommand
 	{
+		private const string VersionSpecificBaseUrl = "/admin/api/{0}";
+
 		public static readonly ShopifyCommand Unknown = new ShopifyCommand( string.Empty );
 		public static readonly ShopifyCommand GetAccessToken = new ShopifyCommand( "/admin/oauth/access_token" );
 		public static readonly ShopifyCommand GetAllOrders = new ShopifyCommand( "/admin/orders.json" );
 		public static readonly ShopifyCommand UpdateProductVariant = new ShopifyCommand( "/admin/variants/" ); // WARN: Obsolete!!! Please use UpdateInventoryLevels
-		public static readonly ShopifyCommand UpdateInventoryLevels = new ShopifyCommand( "/admin/inventory_levels/set.json" );
-		public static readonly ShopifyCommand GetProducts = new ShopifyCommand( "/admin/products.json" );
-		public static readonly ShopifyCommand GetProductsCount = new ShopifyCommand( "/admin/products/count.json" );
-		public static readonly ShopifyCommand GetInventoryLevels = new ShopifyCommand( "/admin/inventory_levels.json" );
-		public static readonly ShopifyCommand GetOrdersCount = new ShopifyCommand( "/admin/orders/count.json" );
-		public static readonly ShopifyCommand GetOrders = new ShopifyCommand( "/admin/orders.json" );
-		public static readonly ShopifyCommand GetLocations = new ShopifyCommand( "/admin/locations.json" );
+		public static readonly ShopifyCommand UpdateInventoryLevels = new ShopifyCommand( "/inventory_levels/set.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetProducts = new ShopifyCommand( "/products.json", ApiVersion.V2019_10 );
+		public static readonly ShopifyCommand GetProductsCount = new ShopifyCommand( "/products/count.json", ApiVersion.V2019_10 );
+		public static readonly ShopifyCommand GetInventoryLevels = new ShopifyCommand( "/inventory_levels.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetOrdersCount = new ShopifyCommand( "/orders/count.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetOrders = new ShopifyCommand( "/orders.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetLocations = new ShopifyCommand( "/locations.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetUsers = new ShopifyCommand( "/admin/users.json" );
 		public static readonly ShopifyCommand GetUser = new ShopifyCommand( "/admin/users/" );
 
@@ -21,6 +23,18 @@
 			this.Command = command;
 		}
 
+		private ShopifyCommand( string commandUrl, string apiVersion )
+		{
+			this.Command = string.Format( VersionSpecificBaseUrl, apiVersion ) + commandUrl;
+		}
+
 		public string Command{ get; private set; }
+	}
+
+	public struct ApiVersion
+	{
+		public const string V2019_04 = "2019-04";
+		public const string V2019_07 = "2019-07";
+		public const string V2019_10 = "2019-10";
 	}
 }

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommand.cs
@@ -12,8 +12,8 @@
 		public static readonly ShopifyCommand GetProducts = new ShopifyCommand( "/products.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetProductsCount = new ShopifyCommand( "/products/count.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetInventoryLevels = new ShopifyCommand( "/inventory_levels.json", ApiVersion.V2019_04 );
-		public static readonly ShopifyCommand GetOrdersCount = new ShopifyCommand( "/orders/count.json", ApiVersion.V2019_04 );
-		public static readonly ShopifyCommand GetOrders = new ShopifyCommand( "/orders.json", ApiVersion.V2019_04 );
+		public static readonly ShopifyCommand GetOrdersCount = new ShopifyCommand( "/orders/count.json", ApiVersion.V2019_10 );
+		public static readonly ShopifyCommand GetOrders = new ShopifyCommand( "/orders.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetLocations = new ShopifyCommand( "/locations.json", ApiVersion.V2019_10 );
 		public static readonly ShopifyCommand GetUsers = new ShopifyCommand( "/admin/users.json" );
 		public static readonly ShopifyCommand GetUser = new ShopifyCommand( "/admin/users/" );

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommandEndpointConfig.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommandEndpointConfig.cs
@@ -7,6 +7,7 @@ namespace ShopifyAccess.Models.Configuration.Command
 		public long SinceId{ get; private set; }
 		public int Limit{ get; private set; }
 
+		//TODO GUARD-220 Every place that calls this will need to be updated to not use page=
 		public ShopifyCommandEndpointConfig( long sinceId, int limit )
 			: this( limit )
 		{

--- a/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommandEndpointConfig.cs
+++ b/src/ShopifyAccess/Models/Configuration/Command/ShopifyCommandEndpointConfig.cs
@@ -4,18 +4,7 @@ namespace ShopifyAccess.Models.Configuration.Command
 {
 	public class ShopifyCommandEndpointConfig
 	{
-		public long SinceId{ get; private set; }
 		public int Limit{ get; private set; }
-
-		//TODO GUARD-220 Every place that calls this will need to be updated to not use page=
-		public ShopifyCommandEndpointConfig( long sinceId, int limit )
-			: this( limit )
-		{
-			Condition.Requires( sinceId, "page" ).IsGreaterOrEqual( 0 );
-			Condition.Requires( limit, "limit" ).IsGreaterThan( 0 );
-
-			this.SinceId = sinceId;
-		}
 
 		public ShopifyCommandEndpointConfig( int limit )
 		{

--- a/src/ShopifyAccess/Services/EndpointsBuilder.cs
+++ b/src/ShopifyAccess/Services/EndpointsBuilder.cs
@@ -68,19 +68,17 @@ namespace ShopifyAccess.Services
 			return endpoint;
 		}
 
-		//TODO GUARD-220 Convert to cursors. "page=" in the Url is getting depricated
-		public static string CreateInventoryLevelsIdsEndpoint( long[] ids, int page, int limit )
+		public static string CreateInventoryLevelsIdsEndpoint( long[] ids, int limit )
 		{
-			// INFO : limit should be 250. Page start from 1. Max of inventory_item_ids is 50.
-			var endpoint = string.Format( "?inventory_item_ids={0}&page={1}&limit={2}", string.Join( ",", ids.Select( x => x ) ), page, limit );
+			// INFO : Max of inventory_item_ids is 50.
+			var endpoint = string.Format( "?inventory_item_ids={0}&limit={1}", string.Join( ",", ids.Select( x => x ) ), limit );
 			return endpoint;
 		}
 
-		//TODO GUARD-220 Convert to cursors. "page=" in the Url is getting depricated
-		public static string CreateInventoryLevelsIdsEndpoint( string[] ids, int page, int limit )
+		public static string CreateInventoryLevelsIdsEndpoint( string[] ids, int limit )
 		{
-			// INFO : limit should be 250. Page start from 1. Max of inventory_item_ids is 50.
-			var endpoint = string.Format( "?location_ids={0}&page={1}&limit={2}", string.Join( ",", ids.Select( x => x ) ), page, limit );
+			// INFO : Max of inventory_item_ids is 50.
+			var endpoint = string.Format( "?location_ids={0}&limit={1}", string.Join( ",", ids.Select( x => x ) ), limit );
 			return endpoint;
 		}
 

--- a/src/ShopifyAccess/Services/EndpointsBuilder.cs
+++ b/src/ShopifyAccess/Services/EndpointsBuilder.cs
@@ -60,20 +60,11 @@ namespace ShopifyAccess.Services
 			return endpoint;
 		}
 
-		public static string CreateGetSinglePageEndpoint( ShopifyCommandEndpointConfig config )
+		public static string CreateGetEndpoint( ShopifyCommandEndpointConfig config )
 		{
 			var endpoint = string.Format( "?{0}={1}",
 				ShopifyCommandEndpointName.Limit.Name, config.Limit
 				);
-			return endpoint;
-		}
-
-		public static string CreateGetNextPageSinceIdEndpoint( ShopifyCommandEndpointConfig config )
-		{
-			var endpoint = string.Format( "?{0}={1}&{2}={3}",
-				ShopifyCommandEndpointName.Limit.Name, config.Limit,
-				ShopifyCommandEndpointName.SinceId.Name, config.SinceId
-			);
 			return endpoint;
 		}
 

--- a/src/ShopifyAccess/Services/EndpointsBuilder.cs
+++ b/src/ShopifyAccess/Services/EndpointsBuilder.cs
@@ -77,6 +77,7 @@ namespace ShopifyAccess.Services
 			return endpoint;
 		}
 
+		//TODO GUARD-220 Convert to cursors. "page=" in the Url is getting depricated
 		public static string CreateInventoryLevelsIdsEndpoint( long[] ids, int page, int limit )
 		{
 			// INFO : limit should be 250. Page start from 1. Max of inventory_item_ids is 50.
@@ -84,6 +85,7 @@ namespace ShopifyAccess.Services
 			return endpoint;
 		}
 
+		//TODO GUARD-220 Convert to cursors. "page=" in the Url is getting depricated
 		public static string CreateInventoryLevelsIdsEndpoint( string[] ids, int page, int limit )
 		{
 			// INFO : limit should be 250. Page start from 1. Max of inventory_item_ids is 50.

--- a/src/ShopifyAccess/Services/PagedResponseService.cs
+++ b/src/ShopifyAccess/Services/PagedResponseService.cs
@@ -30,8 +30,8 @@ namespace ShopifyAccess.Services
 			this.Relationship = linkParts[ 1 ].Trim();
 		}
 
-		public string Url { get; }
-		public string Relationship { get; }
+		public string Url { get; private set; }
+		public string Relationship { get; private set; }
 	}
 
 	public class ResponsePage< T >

--- a/src/ShopifyAccess/Services/PagedResponseService.cs
+++ b/src/ShopifyAccess/Services/PagedResponseService.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace ShopifyAccess.Services
+{
+	public static class PagedResponseService
+	{
+		public static string GetNextPageQueryStrFromHeader( NameValueCollection responseHeaders )
+		{
+			var linkHeaders = responseHeaders.GetValues( "Link" );
+			if( linkHeaders == null || linkHeaders.Length == 0 )
+				return string.Empty;
+
+			var links = linkHeaders.First().Split(',').Select( x => new PageLink ( x.Split(';') ) ).ToArray();
+			if( !links.Any() || links.Last().Relationship != "rel=\"next\"" )
+				return string.Empty;
+
+			var urlWithAngleBraces = links.Last().Url;
+			var url = urlWithAngleBraces.Substring( 1, urlWithAngleBraces.Length - 2 );
+			return new Uri( url ).Query;
+		}
+	}
+
+	internal class PageLink
+	{
+		public PageLink( string[] linkParts )
+		{
+			this.Url = linkParts[ 0 ].Trim();
+			this.Relationship = linkParts[ 1 ].Trim();
+		}
+
+		public string Url { get; }
+		public string Relationship { get; }
+	}
+
+	public class ResponsePage< T >
+	{
+		public T Response;
+		public string NextPageQueryStr;
+	}
+}

--- a/src/ShopifyAccess/ShopifyAccess.csproj
+++ b/src/ShopifyAccess/ShopifyAccess.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <LangVersion>5</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/src/ShopifyAccess/ShopifyAccess.csproj
+++ b/src/ShopifyAccess/ShopifyAccess.csproj
@@ -103,6 +103,7 @@
     <Compile Include="Models\User\ShopifyUsers.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Services\EndpointsBuilder.cs" />
+    <Compile Include="Services\PagedResponseService.cs" />
     <Compile Include="Services\WebRequestServices.cs" />
     <Compile Include="ShopifyFactory.cs" />
     <Compile Include="ShopifyService.cs" />

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Orders/OrdersListTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Orders/OrdersListTests.cs
@@ -41,7 +41,7 @@ namespace ShopifyAccessTests.Orders
 			var service = this.ShopifyFactory.CreateService( this.Config );
 			var orders = service.GetOrders( ShopifyOrderStatus.any, DateTime.UtcNow.AddDays( -10 ), DateTime.UtcNow );
 
-			orders.Count.Should().Be( 1 );
+			orders.Count.Should().BeGreaterThan( 0 );
 		}
 
 		[ Test ]
@@ -50,7 +50,7 @@ namespace ShopifyAccessTests.Orders
 			var service = this.ShopifyFactory.CreateService( this.Config );
 			var orders = await service.GetOrdersAsync( ShopifyOrderStatus.any, DateTime.UtcNow.AddDays( -200 ), DateTime.UtcNow, CancellationToken.None );
 
-			orders.Count.Should().Be( 1 );
+			orders.Count.Should().BeGreaterThan( 0 );
 		}
 
 		[ Test ]

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
@@ -7,7 +7,6 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using LINQtoCSV;
 using Netco.Logging;
-using Netco.Logging.NLogIntegration;
 using NUnit.Framework;
 using ShopifyAccess;
 using ShopifyAccess.Models.Configuration.Command;

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
@@ -19,7 +19,7 @@ namespace ShopifyAccessTests.Products
 	public class ProductVariantTests
 	{
 		private readonly IShopifyFactory ShopifyFactory = new ShopifyFactory();
-		private ShopifyCommandConfig Config;
+		private IShopifyService _service;
 
 		[ SetUp ]
 		public void Init()
@@ -32,14 +32,13 @@ namespace ShopifyAccessTests.Products
 			var testConfig = cc.Read< TestCommandConfig >( credentialsFilePath, new CsvFileDescription { FirstLineHasColumnNames = true } ).FirstOrDefault();
 
 			if( testConfig != null )
-				this.Config = new ShopifyCommandConfig( testConfig.ShopName, testConfig.AccessToken );
+				this._service = this.ShopifyFactory.CreateService( new ShopifyCommandConfig( testConfig.ShopName, testConfig.AccessToken ) );
 		}
 
 		[ Test ]
 		public void GetProducts()
 		{
-			var service = this.ShopifyFactory.CreateService( this.Config );
-			var products = service.GetProducts();
+			var products = this._service.GetProducts();
 
 			products.Products.Count.Should().BeGreaterThan( 0 );
 		}
@@ -47,8 +46,7 @@ namespace ShopifyAccessTests.Products
 		[ Test ]
 		public async Task GetProductsAsync()
 		{
-			var service = this.ShopifyFactory.CreateService( this.Config );
-			var products = await service.GetProductsAsync( CancellationToken.None );
+			var products = await this._service.GetProductsAsync( CancellationToken.None );
 
 			products.Products.Count.Should().BeGreaterThan( 0 );
 		}
@@ -56,33 +54,37 @@ namespace ShopifyAccessTests.Products
 		[ Test ]
 		public async Task GetProductVariantsBySkusAsync()
 		{
-			var service = this.ShopifyFactory.CreateService( this.Config );
-			var products = await service.GetProductsAsync( CancellationToken.None );
+			var products = await this._service.GetProductsAsync( CancellationToken.None );
 			var productVariants = products.ToListVariants();
 
 			// take 10% random variants
 			var filteredProductVariants = productVariants.OrderBy( v => Guid.NewGuid() ).Take( productVariants.Count / 10 ).ToList();
 			var filteredSkus = filteredProductVariants.Select( v => v.Sku.ToUpperInvariant() );
 
-			var variants = await service.GetProductVariantsBySkusAsync( filteredSkus, CancellationToken.None );
+			var variants = await this._service.GetProductVariantsBySkusAsync( filteredSkus, CancellationToken.None );
 			var expectedVariants = productVariants.Where( v => filteredSkus.Contains( v.Sku.ToUpperInvariant() ) ).ToList();
 			variants.ShouldBeEquivalentTo( expectedVariants );
 		}
 
 		[ Test ]
+		public async Task GetProductsThroughLocationsAsync()
+		{
+			var products = await this._service.GetProductsThroughLocationsAsync( CancellationToken.None );
+
+			products.Products.Should().NotBeNullOrEmpty();
+		}
+
+		[ Test ]
 		public void ProductVariantQuantityUpdated()
 		{
-			var service = this.ShopifyFactory.CreateService( this.Config );
-
 			var variantToUpdate = new ShopifyProductVariantForUpdate { Id = 337095344, Quantity = 2 };
-			service.UpdateProductVariants( new List< ShopifyProductVariantForUpdate > { variantToUpdate } );
+			this._service.UpdateProductVariants( new List< ShopifyProductVariantForUpdate > { variantToUpdate } );
 		}
 
 		[ Test ]
 		public void GetAndUpdateProduct()
 		{
-			var service = this.ShopifyFactory.CreateService( this.Config );
-			var products = service.GetProducts().ToDictionary();
+			var products = this._service.GetProducts().ToDictionary();
 
 			var productsForUpdate = new List< ShopifyInventoryLevelForUpdate >();
 			foreach( var product in products )
@@ -106,10 +108,46 @@ namespace ShopifyAccessTests.Products
 				
 			}
 
-			service.UpdateInventoryLevels( productsForUpdate );
-			var updatedProducts = service.GetProducts().ToDictionary();
+			_service.UpdateInventoryLevels( productsForUpdate );
+			var updatedProducts = this._service.GetProducts().ToDictionary();
 			
 			products.Should().Equal( updatedProducts );
+		}
+
+		[ Test ]
+		public async Task GetAndUpdateProductAsync()
+		{
+			const string sku = "testsku1";
+			var inventoryItem = await this.GetFirstInventoryItem( sku );
+			var initialQuantity = inventoryItem.Available;
+			const int quantity = 39;
+
+			await this._service.UpdateInventoryLevelsAsync( CreateInventoryLevelForUpdate( inventoryItem, quantity ) );
+			var product = ( await this._service.GetProductVariantsBySkusAsync( new List< string > { sku }, CancellationToken.None ) ).First();
+			var newQuantity = product.InventoryLevels.InventoryLevels.First().Available;
+			await this._service.UpdateInventoryLevelsAsync( CreateInventoryLevelForUpdate( inventoryItem, initialQuantity ) );
+
+			newQuantity.Should().Be( quantity );
+		}
+
+		private async Task< ShopifyInventoryLevel > GetFirstInventoryItem( string sku )
+		{
+			var product = ( await this._service.GetProductVariantsBySkusAsync( new List< string > { sku }, CancellationToken.None ) ).First();
+			return product.InventoryLevels.InventoryLevels.First();
+		}
+
+		private static IEnumerable< ShopifyInventoryLevelForUpdate > CreateInventoryLevelForUpdate( ShopifyInventoryLevel inventory, int setQuantity )
+		{
+			IEnumerable< ShopifyInventoryLevelForUpdate > inventoryLevels = new List< ShopifyInventoryLevelForUpdate >
+			{
+				new ShopifyInventoryLevelForUpdate
+				{
+					InventoryItemId = inventory.InventoryItemId,
+					Quantity = setQuantity,
+					LocationId = inventory.LocationId
+				}
+			};
+			return inventoryLevels;
 		}
 	}
 }

--- a/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
@@ -86,6 +86,7 @@
     <Compile Include="TestCommandConfig.cs" />
     <Compile Include="Throttler\ThrottlerTests.cs" />
     <Compile Include="Users\UsersTests.cs" />
+    <Compile Include="WebRequestServicesTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/src/ShopifyAccessTests/ShopifyAccessTests/WebRequestServicesTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/WebRequestServicesTests.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Specialized;
+using FluentAssertions;
+using NUnit.Framework;
+using ShopifyAccess.Services;
+
+namespace ShopifyAccessTests
+{
+	[ TestFixture ]
+	public class WebRequestServicesTests
+	{
+		[ Test ]
+		public void GetNextPageLinkFromHeader_IfFirstPage_ShouldReturnNextPage()
+		{
+			var responseHeaders = new NameValueCollection();
+			const string queryStr = "?limit=50&page_info=eyJkaXJlY3";
+			responseHeaders.Add( "Link", 
+				"<https://skuvault.myshopify.com/admin/api/2019-10/products.json" + queryStr + ">; rel=\"next\"" );
+
+			var link = PagedResponseService.GetNextPageQueryStrFromHeader( responseHeaders );
+
+			link.Should().Be( queryStr );
+		}
+
+		[ Test ]
+		public void GetNextPageLinkFromHeader_IfBothPrevAndNextPagesPresent_ShouldReturnNextPage()
+		{
+			var responseHeaders = new NameValueCollection();
+			const string queryStr = "?limit=50&page_info=eyJkaXJlY3";
+			responseHeaders.Add( "Link", 
+			"<https://skuvault.myshopify.com/admin/api/2019-10/products.json?limit=50&page_info=eyJkaXJlY3>; rel=\"previous\", " + 
+			     "<https://skuvault.myshopify.com/admin/api/2019-10/products.json" + queryStr + ">; rel=\"next\"" );
+
+			var link = PagedResponseService.GetNextPageQueryStrFromHeader( responseHeaders );
+
+			link.Should().Be( queryStr );
+		}
+
+		[ Test ]
+		public void GetNextPageLinkFromHeader_IfLastPage_ShouldReturnNothing()
+		{
+			var responseHeaders = new NameValueCollection();
+			responseHeaders.Add( "Link", 
+				"<https://skuvault.myshopify.com/admin/api/2019-10/products.json?limit=50&page_info=eyJkaXJlY3>; rel=\"previous\"" );
+
+			var link = PagedResponseService.GetNextPageQueryStrFromHeader( responseHeaders );
+
+			link.Should().Be( "" );
+		}
+	}
+}


### PR DESCRIPTION
Converted every api that's being used and is version-specific to cursor-based pagination (explicit api version 2019-10)