### PR TITLE
2020-04-02 GUARD-484 Removed-Order-Items-Not-Syncing

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -5,7 +5,7 @@ using System.Runtime.InteropServices;
 [ assembly : ComVisible( false ) ]
 [ assembly : AssemblyProduct( "ShopifyAccess" ) ]
 [ assembly : AssemblyCompany( "SkuVault Inc." ) ]
-[ assembly : AssemblyCopyright( "Copyright (C) 2019 SkuVault Inc." ) ]
+[ assembly : AssemblyCopyright( "Copyright (C) 2020 SkuVault Inc." ) ]
 [ assembly : AssemblyDescription( "Shopify webservices API wrapper." ) ]
 [ assembly : AssemblyTrademark( "" ) ]
 [ assembly : AssemblyCulture( "" ) ]
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.3.1.0" ) ]
+[ assembly : AssemblyVersion( "1.3.2.0" ) ]

--- a/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
+++ b/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
@@ -62,6 +62,9 @@ namespace ShopifyAccess.Models.Order
 		[ DataMember( Name = "tax_lines" ) ]
 		public IEnumerable< ShopifyTaxLine > TaxLines{ get; set; }
 
+		[ DataMember( Name = "refunds" ) ]
+		public IList< ShopifyOrderRefund > Refunds { get; set; }
+
 		public bool IsShipped
 		{
 			get { return this.ClosedAt.HasValue; }
@@ -71,6 +74,30 @@ namespace ShopifyAccess.Models.Order
 		{
 			get { return this.CancelledAt.HasValue; }
 		}
+	}
+
+	[ DataContract ]
+	public class ShopifyOrderRefund
+	{
+		[ DataMember( Name = "id" ) ]
+		public long Id { get; set; }
+		[ DataMember( Name = "order_id" ) ]
+		public long OrderId { get; set; }
+		[ DataMember( Name = "refund_line_items" ) ]
+		public IList< ShopifyOrderRefundLineItem > RefundLineItems { get; set; }
+	}
+
+	[ DataContract ]
+	public class ShopifyOrderRefundLineItem
+	{
+		[ DataMember( Name = "id" ) ]
+		public long Id { get; set; }
+		[ DataMember( Name = "line_item_id" ) ]
+		public long LineItemId { get; set; }
+		[ DataMember( Name = "quantity" ) ]
+		public int Quantity { get; set; }
+		[ DataMember( Name = "restock_type" ) ]
+		public string RestockType { get; set; }
 	}
 
 	public enum ShopifyFinancialStatus

--- a/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
+++ b/src/ShopifyAccess/Models/Order/ShopifyOrder.cs
@@ -63,7 +63,7 @@ namespace ShopifyAccess.Models.Order
 		public IEnumerable< ShopifyTaxLine > TaxLines{ get; set; }
 
 		[ DataMember( Name = "refunds" ) ]
-		public IList< ShopifyOrderRefund > Refunds { get; set; }
+		public IEnumerable< ShopifyOrderRefund > Refunds { get; set; }
 
 		public bool IsShipped
 		{
@@ -84,7 +84,7 @@ namespace ShopifyAccess.Models.Order
 		[ DataMember( Name = "order_id" ) ]
 		public long OrderId { get; set; }
 		[ DataMember( Name = "refund_line_items" ) ]
-		public IList< ShopifyOrderRefundLineItem > RefundLineItems { get; set; }
+		public IEnumerable< ShopifyOrderRefundLineItem > RefundLineItems { get; set; }
 	}
 
 	[ DataContract ]

--- a/src/ShopifyAccess/ShopifyService.cs
+++ b/src/ShopifyAccess/ShopifyService.cs
@@ -146,13 +146,14 @@ namespace ShopifyAccess
 
 					if ( refundLineItem != null && refundLineItem.RestockType.Equals( "cancel" ) )
 					{
-						// complete refund
+						// remove order item
 						if ( orderItem.Quantity == refundLineItem.Quantity )
 						{
 							isCancelled = true;
 							break;
 						}
-					
+						
+						// adjust quantity
 						cancelledQuantity += refundLineItem.Quantity;
 					}
 				}


### PR DESCRIPTION
Summary
Now we take into account completely cancelled or partially cancelled order items (order's refund section).