### PR TITLE
2020-11-09 GUARD-899 Products-Flip-Flop

### DIFF
--- a/src/Global/GlobalAssemblyInfo.cs
+++ b/src/Global/GlobalAssemblyInfo.cs
@@ -24,4 +24,4 @@ using System.Runtime.InteropServices;
 
 // Keep in track with CA API version
 
-[ assembly : AssemblyVersion( "1.4.1.0" ) ]
+[ assembly : AssemblyVersion( "1.6.3.0" ) ]

--- a/src/ShopifyAccess/Misc/Extensions.cs
+++ b/src/ShopifyAccess/Misc/Extensions.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace ShopifyAccess.Misc
+{
+	public static class Extensions
+	{
+		public static string GetUrlWithoutQueryPart( this string rawUrl )
+		{
+			if ( string.IsNullOrWhiteSpace( rawUrl ) )
+				return rawUrl;
+
+			try
+			{
+				var url = new Uri( rawUrl );
+				return url.GetLeftPart( UriPartial.Path );
+			}
+			catch { }
+
+			return rawUrl;
+		}
+	}
+}

--- a/src/ShopifyAccess/Misc/Extensions.cs
+++ b/src/ShopifyAccess/Misc/Extensions.cs
@@ -9,12 +9,11 @@ namespace ShopifyAccess.Misc
 			if ( string.IsNullOrWhiteSpace( rawUrl ) )
 				return rawUrl;
 
-			try
+			Uri url;
+			if ( Uri.TryCreate( rawUrl, UriKind.Absolute, out url ) )
 			{
-				var url = new Uri( rawUrl );
 				return url.GetLeftPart( UriPartial.Path );
 			}
-			catch { }
 
 			return rawUrl;
 		}

--- a/src/ShopifyAccess/ShopifyAccess.csproj
+++ b/src/ShopifyAccess/ShopifyAccess.csproj
@@ -64,6 +64,7 @@
     </Compile>
     <Compile Include="IShopifyService.cs" />
     <Compile Include="Misc\ActionPolicies.cs" />
+    <Compile Include="Misc\Extensions.cs" />
     <Compile Include="Misc\ShopifyLogger.cs" />
     <Compile Include="Misc\ShopifyThrottler.cs" />
     <Compile Include="Models\Configuration\Command\ShopifyOrderCommandEndpoint.cs" />

--- a/src/ShopifyAccess/ShopifyService.cs
+++ b/src/ShopifyAccess/ShopifyService.cs
@@ -207,6 +207,8 @@ namespace ShopifyAccess
 				variant.InventoryLevels = inventoryLevelsForVariant;
 			}
 
+			RemoveQueryPartFromProductsImagesUrl( products );
+
 			return products;
 		}
 
@@ -225,6 +227,8 @@ namespace ShopifyAccess
 				ProductsStartUtc = productsStartUtc
 			};
 			var products = await this.CollectProductsFromAllPagesAsync( productsDateFilter, mark, token );
+			
+			RemoveQueryPartFromProductsImagesUrl( products );
 
 			return products;
 		}
@@ -244,6 +248,8 @@ namespace ShopifyAccess
 				ProductsStartUtc = productsStartUtc
 			};
 			var products = await this.CollectProductsFromAllPagesAsync( productsDateFilter, mark, token );
+
+			RemoveQueryPartFromProductsImagesUrl( products );
 
 			return products;
 		}
@@ -533,6 +539,20 @@ namespace ShopifyAccess
 			foreach( var product in products.Products )
 			{
 				product.Variants.RemoveAll( v => v.InventoryManagement == InventoryManagement.Blank );
+			}
+		}
+
+		private void RemoveQueryPartFromProductsImagesUrl( ShopifyProducts products )
+		{
+			foreach( var product in products.Products )
+			{
+				if ( product.Images == null )
+					return;
+			
+				foreach( var productImage in product.Images )
+				{
+					productImage.Src = productImage.Src.GetUrlWithoutQueryPart();
+				}
 			}
 		}
 		#endregion

--- a/src/ShopifyAccessTests/ShopifyAccessTests/ExtensionsTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/ExtensionsTests.cs
@@ -1,0 +1,57 @@
+﻿using FluentAssertions;
+using NUnit.Framework;
+using ShopifyAccess.Misc;
+
+namespace ShopifyAccessTests
+{
+	public class ExtensionsTests
+	{
+		[ Test ]
+		public void GivenNullUrl_WhenGetUrlWithoutQueryPartIsCalled_ThenNullIsExpected()
+		{
+			string url = null;
+			var urlWithoutQueryPart = url.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().BeNull();
+		}
+
+		[ Test ]
+		public void GivenWhitespaceUrl_WhenGetUrlWithoutQueryPartIsCalled_ThenNullIsExpected()
+		{
+			string url = "";
+			var urlWithoutQueryPart = url.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public void GivenNotValidUrl_WhenGetUrlWithoutQueryPartIsCalled_ThenSameUrlIsExpected()
+		{
+			var notValidUrl = "https://skuvault$$.com::";
+			var urlWithoutQueryPart = notValidUrl.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().Be( notValidUrl );
+		}
+
+		[ Test ]
+		public void GivenUrlWithQueryPart_WhenGetUrlWithoutQueryPartIsCalled_ThenUrlWithoutQueryPartIsExpected()
+		{
+			var urlWithQueryPart = "https://cdn.shopify.com/s/files/5/1077/9210/02010/products/1.jpg?v=1604448440";
+			var urlWithoutQueryPart = urlWithQueryPart.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().Be( "https://cdn.shopify.com/s/files/5/1077/9210/02010/products/1.jpg" );
+		}
+
+		[ Test ]
+		public void GivenUrlWithLongQueryPart_WhenGetUrlWithoutQueryPartIsCalled_ThenUrlWithoutQueryPartIsExpected()
+		{
+			var urlWithQueryPart = "https://cdn.shopify.com/s/files/5/1077/9210/02010/products/1.jpg?v=1604448440&nonce=292929";
+			var urlWithoutQueryPart = urlWithQueryPart.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().Be( "https://cdn.shopify.com/s/files/5/1077/9210/02010/products/1.jpg" );
+		}
+
+		[ Test ]
+		public void GivenValidUrlWithoutQueryPart_WhenGetUrlWithoutQueryPartIsCalled_ThenUrlWithoutQueryPartIsExpected()
+		{
+			var imageUrl = "https://cdn.shopify.com/s/files/5/1077/9210/02010/products/1.jpg";
+			var urlWithoutQueryPart = imageUrl.GetUrlWithoutQueryPart();
+			urlWithoutQueryPart.Should().Be( imageUrl );
+		}
+	}
+}

--- a/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/Products/ProductVariantTests.cs
@@ -148,6 +148,30 @@ namespace ShopifyAccessTests.Products
 			newQuantity.Should().Be( quantity );
 		}
 
+		[ Test ]
+		public async Task WhenGetProductsCreatedAfterAsyncIsCalled_ThenProductsImagesUrlsAreExpectedWithoutQueryPart()
+		{
+			var products = await this._service.GetProductsCreatedAfterAsync( DateTime.UtcNow.AddMonths( -2 ), CancellationToken.None );
+			var productsWithImages = products.Products.Where( p => p.Images != null && p.Images.Any() );
+
+			productsWithImages.Should().NotBeNullOrEmpty();
+
+			var imagesUrlsQueries = productsWithImages.SelectMany( p => p.Images ).Select( i => new Uri( i.Src ).Query ).Where( q => !string.IsNullOrWhiteSpace( q ) );
+			imagesUrlsQueries.Should().BeEmpty();
+		}
+
+		[ Test ]
+		public async Task WhenGetProductsCreatedBeforeButUpdatedAfterAsyncIsCalled_ThenProductsImagesUrlsAreExpectedWithoutQueryPart()
+		{
+			var products = await this._service.GetProductsCreatedBeforeButUpdatedAfterAsync( DateTime.UtcNow.AddMonths( -2 ), CancellationToken.None );
+			var productsWithImages = products.Products.Where( p => p.Images != null && p.Images.Any() );
+
+			productsWithImages.Should().NotBeNullOrEmpty();
+
+			var imagesUrlsQueries = productsWithImages.SelectMany( p => p.Images ).Select( i => new Uri( i.Src ).Query ).Where( q => !string.IsNullOrWhiteSpace( q ) );
+			imagesUrlsQueries.Should().BeEmpty();
+		}
+
 		private async Task< ShopifyInventoryLevel > GetFirstInventoryItem( string sku )
 		{
 			var product = ( await this._service.GetProductVariantsInventoryBySkusAsync( new List< string > { sku }, CancellationToken.None ) ).First();

--- a/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
+++ b/src/ShopifyAccessTests/ShopifyAccessTests/ShopifyAccessTests.csproj
@@ -79,6 +79,7 @@
     </Compile>
     <Compile Include="Cancellation\CancellationTokenTests.cs" />
     <Compile Include="EndpointsBuilderTests.cs" />
+    <Compile Include="ExtensionsTests.cs" />
     <Compile Include="Locations\LocationListTests.cs" />
     <Compile Include="Orders\OrderMapperTests.cs" />
     <Compile Include="Orders\OrdersListTests.cs" />


### PR DESCRIPTION
**Summary**
Removed query part from products images urls.

Technical details:
Shopify sometimes adds/updates query part in the product image url which causes massive updates in SkuVault especially when tenant has large catalog.

Example:
`https://cdn.shopify.com/s/files/1/1494/4308/products/AW030503f_fff5a140-ad97-4130-9f22-00672e851107.jpg?v=1571611702`

